### PR TITLE
Add request rendering with syntax highlighting

### DIFF
--- a/tests/test_format_response.py
+++ b/tests/test_format_response.py
@@ -7,7 +7,7 @@ from pygments.lexers import HttpLexer, JsonLexer, TextLexer
 from rich.syntax import Syntax
 
 from vedro_httpx import Response
-from vedro_httpx._render_headers import format_response_headers
+from vedro_httpx._render_headers import HttpHeadersLexer, format_response_headers
 from vedro_httpx._render_request import render_request
 from vedro_httpx._render_response import format_response_body, render_response
 
@@ -164,7 +164,7 @@ def test_render_response_with_get_request():
             "host: get_url.com",
             "user-agent: pytest",
         ])
-        assert isinstance(headers_syntax.lexer, TextLexer)
+        assert isinstance(headers_syntax.lexer, HttpHeadersLexer)
 
 
 def test_render_response_with_post_request_json():
@@ -191,7 +191,7 @@ def test_render_response_with_post_request_json():
             "content-type: application/json",
             "content-length: 8"
         ])
-        assert isinstance(headers_syntax.lexer, TextLexer)
+        assert isinstance(headers_syntax.lexer, HttpHeadersLexer)
 
         assert isinstance(body_syntax, Syntax)
         assert body_syntax.code == '"{\\"id\\":1}"'
@@ -225,7 +225,7 @@ def test_render_response_with_patch_request_form_urlencoded():
             "content-length: 18",
             "content-type: application/x-www-form-urlencoded",
         ])
-        assert isinstance(headers_syntax.lexer, TextLexer)
+        assert isinstance(headers_syntax.lexer, HttpHeadersLexer)
 
         assert isinstance(body_syntax, Syntax)
         assert body_syntax.code == 'id=1\n&name=TestName'

--- a/tests/test_format_response.py
+++ b/tests/test_format_response.py
@@ -164,7 +164,7 @@ def test_render_response_with_get_request():
             "host: get_url.com",
             "user-agent: pytest",
         ])
-        assert isinstance(headers_syntax.lexer, HttpLexer)
+        assert isinstance(headers_syntax.lexer, TextLexer)
 
 
 def test_render_response_with_post_request_json():
@@ -191,7 +191,7 @@ def test_render_response_with_post_request_json():
             "content-type: application/json",
             "content-length: 8"
         ])
-        assert isinstance(headers_syntax.lexer, HttpLexer)
+        assert isinstance(headers_syntax.lexer, TextLexer)
 
         assert isinstance(body_syntax, Syntax)
         assert body_syntax.code == '"{\\"id\\":1}"'
@@ -225,7 +225,7 @@ def test_render_response_with_patch_request_form_urlencoded():
             "content-length: 18",
             "content-type: application/x-www-form-urlencoded",
         ])
-        assert isinstance(headers_syntax.lexer, HttpLexer)
+        assert isinstance(headers_syntax.lexer, TextLexer)
 
         assert isinstance(body_syntax, Syntax)
         assert body_syntax.code == 'id=1\n&name=TestName'

--- a/tests/test_format_response.py
+++ b/tests/test_format_response.py
@@ -7,11 +7,9 @@ from pygments.lexers import HttpLexer, JsonLexer, TextLexer
 from rich.syntax import Syntax
 
 from vedro_httpx import Response
-from vedro_httpx._render_response import (
-    format_response_body,
-    format_response_headers,
-    render_response, render_request,
-)
+from vedro_httpx._render_headers import format_response_headers
+from vedro_httpx._render_request import render_request
+from vedro_httpx._render_response import format_response_body, render_response
 
 
 def test_format_response_no_headers():
@@ -207,7 +205,7 @@ def test_render_response_with_patch_request_form_urlencoded():
             url='http://get_url.com',
             params={'test': 1},
             headers={'User-Agent': 'pytest'},
-            data={'id': 1}
+            data={'id': 1, 'name': 'TestName'}
         )
 
     with when:
@@ -224,12 +222,12 @@ def test_render_response_with_patch_request_form_urlencoded():
             "accept-encoding: gzip, deflate",
             "connection: keep-alive",
             "user-agent: pytest",
-            "content-length: 4",
+            "content-length: 18",
             "content-type: application/x-www-form-urlencoded",
         ])
         assert isinstance(headers_syntax.lexer, HttpLexer)
 
         assert isinstance(body_syntax, Syntax)
-        assert body_syntax.code == '{\n    "id": "1"\n}'
-        assert isinstance(body_syntax.lexer, JsonLexer)
+        assert body_syntax.code == 'id=1\n&name=TestName'
+        assert isinstance(body_syntax.lexer, TextLexer)
 

--- a/tests/test_format_response.py
+++ b/tests/test_format_response.py
@@ -54,7 +54,7 @@ def test_format_response_no_body():
 
     with then:
         assert code == "<binary preview=b'' len=0>"
-        assert lexer == ""
+        assert isinstance(lexer, TextLexer)
 
 
 def test_format_response_no_content_type():
@@ -67,7 +67,7 @@ def test_format_response_no_content_type():
 
     with then:
         assert code == f"<binary preview={body[:10]} len={len(body)}>"
-        assert lexer == ""
+        assert isinstance(lexer, TextLexer)
 
 
 def test_format_response_text():
@@ -157,7 +157,7 @@ def test_render_response_with_get_request():
     with then:
         request_url_text, headers_syntax = list(res)
 
-        assert request_url_text == "\n→ Request GET http://get_url.com?test=1"
+        assert request_url_text == "→ Request GET http://get_url.com?test=1"
 
         assert isinstance(headers_syntax, Syntax)
         assert headers_syntax.code == linesep.join([
@@ -182,7 +182,7 @@ def test_render_response_with_post_request_json():
 
     with then:
         request_url_text, headers_syntax, body_syntax = list(res)
-        assert request_url_text == "\n→ Request POST http://get_url.com?test=1"
+        assert request_url_text == "→ Request POST http://get_url.com?test=1"
 
         assert isinstance(headers_syntax, Syntax)
         assert headers_syntax.code == linesep.join([
@@ -213,7 +213,7 @@ def test_render_response_with_patch_request_form_urlencoded():
 
     with then:
         request_url_text, headers_syntax, body_syntax = list(res)
-        assert request_url_text == "\n→ Request PATCH http://get_url.com?test=1"
+        assert request_url_text == "→ Request PATCH http://get_url.com?test=1"
 
         assert isinstance(headers_syntax, Syntax)
         assert headers_syntax.code == linesep.join([
@@ -228,6 +228,5 @@ def test_render_response_with_patch_request_form_urlencoded():
         assert isinstance(headers_syntax.lexer, HttpHeadersLexer)
 
         assert isinstance(body_syntax, Syntax)
-        assert body_syntax.code == 'id=1\n&name=TestName'
-        assert isinstance(body_syntax.lexer, TextLexer)
-
+        assert body_syntax.code == '{\n    "id": "1",\n    "name": "TestName"\n}'
+        assert isinstance(body_syntax.lexer, JsonLexer)

--- a/tests/test_print_response.py
+++ b/tests/test_print_response.py
@@ -42,7 +42,7 @@ def test_render_response_console(*, console: Console, buffer: StringIO):
 
     with then:
         assert buffer.getvalue() == linesep.join([
-            'Response:',
+            '← Response',
             '[94mHTTP[0m/[94m1.1[0m [94m200[0m [96mOK[0m',
             '[96mcontent-type[0m: application/json',
             f'[96mx-token[0m: {header_val}',
@@ -82,7 +82,7 @@ def test_render_response_console_width(*, console: Console, buffer: StringIO):
         body_len = width - len('│   "name": "') - 1
 
         assert output == linesep.join([
-            'Response:',
+            '← Response',
             '[94mHTTP[0m/[94m1.1[0m [94m200[0m [96mOK[0m',
             '[96mcontent-type[0m: application/json',
             f'[96mx-token[0m: {header_val[:header_len]}…',

--- a/vedro_httpx/_render_headers.py
+++ b/vedro_httpx/_render_headers.py
@@ -3,7 +3,7 @@ from typing import List, Tuple
 
 from httpx._models import Headers, Request, Response
 from pygments.lexer import Lexer
-from pygments.lexers import HttpLexer, TextLexer
+from pygments.lexers import HttpLexer
 
 __all__ = ("format_request_headers", "format_response_headers")
 
@@ -15,6 +15,13 @@ def headers_lines(headers: Headers) -> List[str]:
             lines.append(f"{header}: {value}")
     return lines
 
+
+class HttpHeadersLexer(HttpLexer):
+    header_callback = HttpLexer.header_callback
+    tokens = {
+        'root': [(r'([^\s:]+)( *)(:)( *)([^\r\n]*)(\r?\n|\Z)', header_callback)],
+    }
+
 def format_request_headers(request: Request) -> Tuple[str, Lexer]:
     """
     Format the HTTP headers of a request and determine the appropriate lexer for syntax
@@ -25,7 +32,7 @@ def format_request_headers(request: Request) -> Tuple[str, Lexer]:
              HttpLexer instance.
     """
     lines = headers_lines(request.headers)
-    return os.linesep.join(lines), TextLexer()
+    return os.linesep.join(lines), HttpHeadersLexer()
 
 
 def format_response_headers(response: Response) -> Tuple[str, Lexer]:

--- a/vedro_httpx/_render_headers.py
+++ b/vedro_httpx/_render_headers.py
@@ -1,0 +1,42 @@
+import os
+from typing import List, Tuple
+
+from httpx._models import Headers, Request, Response
+from pygments.lexer import Lexer
+from pygments.lexers import HttpLexer
+
+__all__ = ("format_request_headers", "format_response_headers")
+
+def headers_lines(headers: Headers) -> List[str]:
+    lines = []
+    for header in headers:
+        values = headers.get_list(header)
+        for value in values:
+            lines.append(f"{header}: {value}")
+    return lines
+
+def format_request_headers(request: Request) -> Tuple[str, Lexer]:
+    """
+    Format the HTTP headers of a request and determine the appropriate lexer for syntax
+    highlighting.
+
+    :param request: The HTTP request object whose headers are to be formatted.
+    :return: A tuple containing the formatted headers as a string and the corresponding
+             HttpLexer instance.
+    """
+    lines = headers_lines(request.headers)
+    return os.linesep.join(lines), HttpLexer()
+
+
+def format_response_headers(response: Response) -> Tuple[str, Lexer]:
+    """
+    Format the HTTP headers of a response and determine the appropriate lexer for syntax
+    highlighting.
+
+    :param response: The HTTP response object whose headers are to be formatted.
+    :return: A tuple containing the formatted headers as a string and the corresponding
+             HttpLexer instance.
+    """
+    lines = [f"{response.http_version} {response.status_code} {response.reason_phrase}"]
+    lines.extend(headers_lines(response.headers))
+    return os.linesep.join(lines), HttpLexer()

--- a/vedro_httpx/_render_headers.py
+++ b/vedro_httpx/_render_headers.py
@@ -3,7 +3,7 @@ from typing import List, Tuple
 
 from httpx._models import Headers, Request, Response
 from pygments.lexer import Lexer
-from pygments.lexers import HttpLexer
+from pygments.lexers import HttpLexer, TextLexer
 
 __all__ = ("format_request_headers", "format_response_headers")
 
@@ -25,7 +25,7 @@ def format_request_headers(request: Request) -> Tuple[str, Lexer]:
              HttpLexer instance.
     """
     lines = headers_lines(request.headers)
-    return os.linesep.join(lines), HttpLexer()
+    return os.linesep.join(lines), TextLexer()
 
 
 def format_response_headers(response: Response) -> Tuple[str, Lexer]:

--- a/vedro_httpx/_render_headers.py
+++ b/vedro_httpx/_render_headers.py
@@ -3,9 +3,10 @@ from typing import List, Tuple
 
 from httpx._models import Headers, Request, Response
 from pygments.lexer import Lexer
-from pygments.lexers import HttpLexer
+from pygments.lexers.textfmts import HttpLexer
 
 __all__ = ("format_request_headers", "format_response_headers")
+
 
 def headers_lines(headers: Headers) -> List[str]:
     lines = []
@@ -21,6 +22,7 @@ class HttpHeadersLexer(HttpLexer):
     tokens = {
         'root': [(r'([^\s:]+)( *)(:)( *)([^\r\n]*)(\r?\n|\Z)', header_callback)],
     }
+
 
 def format_request_headers(request: Request) -> Tuple[str, Lexer]:
     """

--- a/vedro_httpx/_render_json.py
+++ b/vedro_httpx/_render_json.py
@@ -1,0 +1,8 @@
+import json
+from typing import Any
+
+__all__ = ("get_pretty_json")
+
+
+def get_pretty_json(code: Any) -> str:
+    return json.dumps(code, indent=4, ensure_ascii=False)

--- a/vedro_httpx/_render_request.py
+++ b/vedro_httpx/_render_request.py
@@ -1,0 +1,52 @@
+import json
+from typing import Any, Optional, Tuple, Union
+
+from httpx._models import Request
+from pygments.lexer import Lexer
+from pygments.lexers import JsonLexer, TextLexer, UrlEncodedLexer, get_lexer_for_mimetype
+from pygments.util import ClassNotFound
+from rich.console import RenderResult
+from rich.syntax import Syntax
+
+__all__ = ( "render_request")
+
+from vedro_httpx._render_headers import format_request_headers
+
+
+def render_request(request: Request, *,
+                   theme: str = "ansi_dark", width: Optional[int] = None) -> RenderResult:
+    yield f"\n→ Request {request.method} {request.url}"
+    headers, http_lexer = format_request_headers(request)
+    yield Syntax(headers, http_lexer, theme=theme, word_wrap=True, code_width=width)
+
+    body, lexer = format_request_body(request)
+    if body is not None:
+        yield Syntax(body, lexer, theme=theme, word_wrap=True, code_width=width)
+
+
+
+def format_request_body(request: Request) -> Tuple[Any, Union[Lexer, str]]:
+    content_type = request.headers.get("Content-Type", "")
+    mime_type, *_ = content_type.split(";")
+
+    if content_type == "" or mime_type == 'multipart/form-data':
+        return None, ""
+
+    try:
+        lexer = get_lexer_for_mimetype(mime_type.strip())
+    except ClassNotFound:
+        preview = request.content[:10]
+        return f"<binary preview={preview!r} len={len(request.content)}>", ""
+
+    code = request.content.decode('utf-8')
+    if isinstance(lexer, JsonLexer):
+        try:
+            code = json.dumps(request.content.decode('utf-8'), indent=4)
+        except Exception:
+            return code, TextLexer()
+
+    if isinstance(lexer, UrlEncodedLexer):
+        if isinstance(lexer, UrlEncodedLexer):
+            body = request.content.decode('utf-8').replace('&', '\n&')
+            return body, TextLexer()
+    return code, lexer

--- a/vedro_httpx/_render_response.py
+++ b/vedro_httpx/_render_response.py
@@ -1,6 +1,7 @@
 import json
 from typing import Any, Optional, Tuple, Union
 
+import rich
 from httpx import Response
 from pygments.lexer import Lexer
 from pygments.lexers import JsonLexer, TextLexer, get_lexer_for_mimetype

--- a/vedro_httpx/_render_response.py
+++ b/vedro_httpx/_render_response.py
@@ -1,23 +1,16 @@
 import json
-import os
-from typing import Any, Dict, List, Optional, Tuple, Union
-from urllib.parse import parse_qs
+from typing import Any, Optional, Tuple, Union
 
 from httpx import Response
-from httpx._models import Headers, Request
 from pygments.lexer import Lexer
-from pygments.lexers import (
-    HttpLexer,
-    JsonLexer,
-    TextLexer,
-    UrlEncodedLexer,
-    get_lexer_for_mimetype,
-)
+from pygments.lexers import JsonLexer, TextLexer, get_lexer_for_mimetype
 from pygments.util import ClassNotFound
 from rich.console import RenderResult
 from rich.syntax import Syntax
 
-__all__ = ("render_response", "render_request")
+__all__ = ("render_response")
+
+from vedro_httpx._render_headers import format_response_headers
 
 
 def render_response(response: Response, *,
@@ -43,52 +36,6 @@ def render_response(response: Response, *,
                  theme=theme, word_wrap=True, indent_guides=True, code_width=width)
 
 
-def render_request(request: Request, *,
-                   theme: str = "ansi_dark", width: Optional[int] = None) -> RenderResult:
-    yield f"\n→ Request {request.method} {request.url}"
-    headers, http_lexer = format_request_headers(request)
-    yield Syntax(headers, http_lexer, theme=theme, word_wrap=True, code_width=width)
-
-    body, lexer = format_request_body(request)
-    if body is not None:
-        yield Syntax(body, lexer, theme=theme, word_wrap=True, code_width=width)
-
-def headers_lines(headers: Headers) -> List[str]:
-    lines = []
-    for header in headers:
-        values = headers.get_list(header)
-        for value in values:
-            lines.append(f"{header}: {value}")
-    return lines
-
-
-def format_request_headers(request: Request) -> Tuple[str, Lexer]:
-    """
-    Format the HTTP headers of a request and determine the appropriate lexer for syntax
-    highlighting.
-
-    :param request: The HTTP request object whose headers are to be formatted.
-    :return: A tuple containing the formatted headers as a string and the corresponding
-             HttpLexer instance.
-    """
-    lines = headers_lines(request.headers)
-    return os.linesep.join(lines), HttpLexer()
-
-
-def format_response_headers(response: Response) -> Tuple[str, Lexer]:
-    """
-    Format the HTTP headers of a response and determine the appropriate lexer for syntax
-    highlighting.
-
-    :param response: The HTTP response object whose headers are to be formatted.
-    :return: A tuple containing the formatted headers as a string and the corresponding
-             HttpLexer instance.
-    """
-    lines = [f"{response.http_version} {response.status_code} {response.reason_phrase}"]
-    lines.extend(headers_lines(response.headers))
-    return os.linesep.join(lines), HttpLexer()
-
-
 def format_response_body(response: Response) -> Tuple[Any, Union[Lexer, str]]:
     """
     Format the body of an HTTP response and select an appropriate lexer for syntax highlighting.
@@ -112,36 +59,7 @@ def format_response_body(response: Response) -> Tuple[Any, Union[Lexer, str]]:
     code = response.text
     if isinstance(lexer, JsonLexer):
         try:
-            code = json.dumps(response.json(), indent=4)
-        except Exception:
-            return code, TextLexer()
-    return code, lexer
-
-def format_request_body(request: Request) -> Tuple[Any, Union[Lexer, str]]:
-    content_type = request.headers.get("Content-Type", "")
-    mime_type, *_ = content_type.split(";")
-
-    if content_type == "" or mime_type == 'multipart/form-data':
-        return None, ""
-
-    try:
-        lexer = get_lexer_for_mimetype(mime_type.strip())
-    except ClassNotFound:
-        preview = request.content[:10]
-        return f"<binary preview={preview!r} len={len(request.content)}>", ""
-
-    code = request.content.decode('utf-8')
-    if isinstance(lexer, JsonLexer):
-        try:
-            code = json.dumps(request.content.decode('utf-8'), indent=4)
-        except Exception:
-            return code, TextLexer()
-
-    if isinstance(lexer, UrlEncodedLexer):
-        try:
-            parsed_data = parse_qs(request.content.decode('utf-8'))
-            return json.dumps({key: value[0] for key, value in parsed_data.items()},
-                              indent=4), JsonLexer()
+            code = json.dumps(response.json(), indent=4, ensure_ascii=False)
         except Exception:
             return code, TextLexer()
     return code, lexer

--- a/vedro_httpx/_render_response.py
+++ b/vedro_httpx/_render_response.py
@@ -1,15 +1,23 @@
 import json
 import os
-from typing import Any, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
+from urllib.parse import parse_qs
 
 from httpx import Response
+from httpx._models import Headers, Request
 from pygments.lexer import Lexer
-from pygments.lexers import HttpLexer, JsonLexer, TextLexer, get_lexer_for_mimetype
+from pygments.lexers import (
+    HttpLexer,
+    JsonLexer,
+    TextLexer,
+    UrlEncodedLexer,
+    get_lexer_for_mimetype,
+)
 from pygments.util import ClassNotFound
 from rich.console import RenderResult
 from rich.syntax import Syntax
 
-__all__ = ("render_response",)
+__all__ = ("render_response", "render_request")
 
 
 def render_response(response: Response, *,
@@ -35,6 +43,40 @@ def render_response(response: Response, *,
                  theme=theme, word_wrap=True, indent_guides=True, code_width=width)
 
 
+def render_request(request: Request, *,
+                   theme: str = "ansi_dark", width: Optional[int] = None) -> RenderResult:
+    yield f"{request.method} {request.url}"
+    yield "Request headers:"
+    headers, http_lexer = format_request_headers(request)
+    yield Syntax(headers, http_lexer, theme=theme, word_wrap=True, code_width=width)
+
+    body, lexer = format_request_body(request)
+    if body is not None:
+        yield "Request body:"
+        yield Syntax(body, lexer, theme=theme, word_wrap=True, code_width=width)
+
+def headers_lines(headers: Headers) -> List[str]:
+    lines = []
+    for header in headers:
+        values = headers.get_list(header)
+        for value in values:
+            lines.append(f"{header}: {value}")
+    return lines
+
+
+def format_request_headers(request: Request) -> Tuple[str, Lexer]:
+    """
+    Format the HTTP headers of a request and determine the appropriate lexer for syntax
+    highlighting.
+
+    :param request: The HTTP request object whose headers are to be formatted.
+    :return: A tuple containing the formatted headers as a string and the corresponding
+             HttpLexer instance.
+    """
+    lines = headers_lines(request.headers)
+    return os.linesep.join(lines), HttpLexer()
+
+
 def format_response_headers(response: Response) -> Tuple[str, Lexer]:
     """
     Format the HTTP headers of a response and determine the appropriate lexer for syntax
@@ -45,11 +87,7 @@ def format_response_headers(response: Response) -> Tuple[str, Lexer]:
              HttpLexer instance.
     """
     lines = [f"{response.http_version} {response.status_code} {response.reason_phrase}"]
-    for header in response.headers:
-        values = response.headers.get_list(header)
-        for value in values:
-            lines.append(f"{header}: {value}")
-
+    lines.extend(headers_lines(response.headers))
     return os.linesep.join(lines), HttpLexer()
 
 
@@ -77,6 +115,35 @@ def format_response_body(response: Response) -> Tuple[Any, Union[Lexer, str]]:
     if isinstance(lexer, JsonLexer):
         try:
             code = json.dumps(response.json(), indent=4)
+        except Exception:
+            return code, TextLexer()
+    return code, lexer
+
+def format_request_body(request: Request) -> Tuple[Any, Union[Lexer, str]]:
+    content_type = request.headers.get("Content-Type", "")
+    mime_type, *_ = content_type.split(";")
+
+    if content_type == "" or mime_type == 'multipart/form-data':
+        return None, ""
+
+    try:
+        lexer = get_lexer_for_mimetype(mime_type.strip())
+    except ClassNotFound:
+        preview = request.content[:10]
+        return f"<binary preview={preview!r} len={len(request.content)}>", ""
+
+    code = request.content.decode('utf-8')
+    if isinstance(lexer, JsonLexer):
+        try:
+            code = json.dumps(request.content.decode('utf-8'), indent=4)
+        except Exception:
+            return code, TextLexer()
+
+    if isinstance(lexer, UrlEncodedLexer):
+        try:
+            parsed_data = parse_qs(request.content.decode('utf-8'))
+            return json.dumps({key: value[0] for key, value in parsed_data.items()},
+                              indent=4), JsonLexer()
         except Exception:
             return code, TextLexer()
     return code, lexer

--- a/vedro_httpx/_render_response.py
+++ b/vedro_httpx/_render_response.py
@@ -34,7 +34,7 @@ def render_response(response: Response, *,
     :param width: The maximum width for the code blocks. If not set, defaults to console width.
     :return: Yields formatted rich syntax objects for headers and body.
     """
-    yield "Response:"
+    yield "← Response"
     headers, http_lexer = format_response_headers(response)
     yield Syntax(headers, http_lexer, theme=theme, word_wrap=True, code_width=width)
 
@@ -45,14 +45,12 @@ def render_response(response: Response, *,
 
 def render_request(request: Request, *,
                    theme: str = "ansi_dark", width: Optional[int] = None) -> RenderResult:
-    yield f"{request.method} {request.url}"
-    yield "Request headers:"
+    yield f"\n→ Request {request.method} {request.url}"
     headers, http_lexer = format_request_headers(request)
     yield Syntax(headers, http_lexer, theme=theme, word_wrap=True, code_width=width)
 
     body, lexer = format_request_body(request)
     if body is not None:
-        yield "Request body:"
         yield Syntax(body, lexer, theme=theme, word_wrap=True, code_width=width)
 
 def headers_lines(headers: Headers) -> List[str]:

--- a/vedro_httpx/_render_response.py
+++ b/vedro_httpx/_render_response.py
@@ -1,7 +1,5 @@
-import json
 from typing import Any, Optional, Tuple, Union
 
-import rich
 from httpx import Response
 from pygments.lexer import Lexer
 from pygments.lexers import JsonLexer, TextLexer, get_lexer_for_mimetype
@@ -12,6 +10,7 @@ from rich.syntax import Syntax
 __all__ = ("render_response")
 
 from vedro_httpx._render_headers import format_response_headers
+from vedro_httpx._render_json import get_pretty_json
 
 
 def render_response(response: Response, *,
@@ -54,13 +53,13 @@ def format_response_body(response: Response) -> Tuple[Any, Union[Lexer, str]]:
     try:
         lexer = get_lexer_for_mimetype(mime_type.strip())
     except ClassNotFound:
-        preview = response.content[:10]
-        return f"<binary preview={preview!r} len={len(response.content)}>", ""
+        code = f"<binary preview={response.content[:10]!r} len={len(response.content)}>"
+        return code, TextLexer()
 
     code = response.text
     if isinstance(lexer, JsonLexer):
         try:
-            code = json.dumps(response.json(), indent=4, ensure_ascii=False)
+            code = get_pretty_json(response.json())
         except Exception:
             return code, TextLexer()
     return code, lexer

--- a/vedro_httpx/_response.py
+++ b/vedro_httpx/_response.py
@@ -1,12 +1,8 @@
-import json
-from json import JSONDecodeError
-
-from httpx._status_codes import codes
-
 from httpx import Response as _Response
 from rich.console import Console, ConsoleOptions, RenderResult
 
-from ._render_response import render_request, render_response
+from ._render_request import render_request
+from ._render_response import render_response
 
 __all__ = ("Response",)
 

--- a/vedro_httpx/_response.py
+++ b/vedro_httpx/_response.py
@@ -1,7 +1,9 @@
+import json
+
 from httpx import Response as _Response
 from rich.console import Console, ConsoleOptions, RenderResult
 
-from ._render_response import render_response
+from ._render_response import render_request, render_response
 
 __all__ = ("Response",)
 
@@ -28,4 +30,6 @@ class Response(_Response):
         # are the same, then a specific width limit has been set and we use options.max_width.
         # If not, we use a large default width of 1024^2 (which practically means no width limit).
         width = options.max_width if options.min_width == options.max_width else 1024 ** 2
+        if self._request:
+            yield from render_request(self.request, width=width)
         yield from render_response(self, width=width)

--- a/vedro_httpx/_response.py
+++ b/vedro_httpx/_response.py
@@ -1,4 +1,7 @@
 import json
+from json import JSONDecodeError
+
+from httpx._status_codes import codes
 
 from httpx import Response as _Response
 from rich.console import Console, ConsoleOptions, RenderResult


### PR DESCRIPTION
Print request info in response
 
Example: 
<img width="1100" alt="image" src="https://github.com/user-attachments/assets/70e8faca-5c84-46bc-a44a-98d04b1d58ad" />
